### PR TITLE
docs/ci: PR por unidad funcional y paths-ignore de docs (-beta.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 on:
   pull_request:
     branches: [ "reset/main" ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '**/*.mdx'
 
 jobs:
   lint:

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,8 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+echo "ℹ️  Política de PR: Usa scripts/pr-flow.sh (open/status/rerun-ci/merge/cleanup) para gestionar PRs hacia reset/main."
+
 npm run lint --silent -- --max-warnings=0 || { echo "\n💥 Lint falló"; exit 1; }
 # Ejecutar tests localmente ralentiza; delegamos a CI. Mantener este comando comentado o protegido por variable.
 if [ "${RUN_LOCAL_TESTS-}" = "1" ]; then

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,6 +52,11 @@ Convenciones Git/PR:
 - No se puede pushear directo a `reset/main` (protegida).
 - Tras merge, limpiar ramas locales/remotas (excepto `autosave`, `stable/*` y soporte activo).
 
+Política de PR (unidad funcional):
+- Abrir PR por unidad funcional coherente (no por cada microcambio). Objetivo: ≤ ~300 líneas netas, 1–3 archivos relacionados.
+- Usar commits atómicos dentro del PR y realizar squash merge.
+- Cambios de solo documentación pueden agruparse; el CI puede ignorarlos (ver filtro de paths en CI).
+
 ### 4) Lint y tests
 - Lint: `npm run lint -- --max-warnings=0`.
 - Tests: `npm test` (Vitest + Testing Library). Mocks críticos:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -44,6 +44,8 @@ VITE_DEV_PORT=5173
 - `scripts/cleanup-branches.sh`: elimina ramas locales mergeadas y remotas seleccionadas; usa `git fetch -p`.
 - `scripts/context-dump.sh`: imprime resumen de repo/entorno para soporte.
 
+Requisito de equipo: Se deben usar los comandos de `scripts/pr-flow.sh` para abrir, consultar estado, relanzar CI y fusionar PRs hacia `reset/main`. Evitar usar directamente `git push` a `reset/main` o abrir/fusionar PRs fuera de este flujo.
+
 Convenciones Git/PR:
 - Trabajar en rama feature/fix/chore; abrir PR hacia `reset/main`.
 - CI se ejecuta en `pull_request` (lint con `--max-warnings=0`, tests).
@@ -84,7 +86,7 @@ Convenciones Git/PR:
 ### 9) Paquete de estado (context-dump)
 Ejecutar `scripts/context-dump.sh` para imprimir:
 - rama actual, sync con remoto, PR asociado (si `gh` está disponible).
-- versión `package.json`, scripts clave.
+- Versión `package.json`, scripts clave.
 - variables requeridas por `.env.example`.
 
 ### 10) Buenas prácticas

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-timesheet-app",
-  "version": "0.2.5-beta.4",
+  "version": "0.2.5-beta.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-timesheet-app",
-  "version": "0.2.5-beta.3",
+  "version": "0.2.5-beta.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Documenta PR por unidad funcional y evita CI en cambios solo de docs. Sin cambios funcionales.